### PR TITLE
Fix like lookup in getUserSayings

### DIFF
--- a/src/lib/db-service.ts
+++ b/src/lib/db-service.ts
@@ -229,7 +229,7 @@ export async function getUserSayings(userIdOrEmail: string | number): Promise<Sa
           .select()
           .from(Likes)
           .where(and(
-            eq(Likes.userId, numericUserId), 
+            eq(Likes.userId, dbUserId),
             eq(Likes.sayingId, saying.id)
           ))
           .get()


### PR DESCRIPTION
## Summary
- correct likes filter to use `dbUserId`

## Testing
- `npm run lint` *(fails: The 'jiti' library is required)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find type definition file '@auth/core')*

------
https://chatgpt.com/codex/tasks/task_e_6855ac82a60c8327b6354374198e94df