### PR TITLE
Ensure numeric IDs in session and API

### DIFF
--- a/.auth/config.ts
+++ b/.auth/config.ts
@@ -45,7 +45,7 @@ export default defineConfig({
 
       if (session.user) {
         // Ensure we always have an ID - use token.id or token.sub
-        session.user.id = (token.id || token.sub) as string;
+        session.user.id = Number(token.id || token.sub);
       }
 
       return session;

--- a/auth.config.ts
+++ b/auth.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
         
         // Create a mock user for development
         return {
-          id: "1",
+          id: 1,
           name: credentials.name || "Dev User",
           email: credentials.email,
           image: "https://avatars.githubusercontent.com/u/1?v=4",
@@ -90,13 +90,8 @@ export default defineConfig({
             return false;
           }
 
-          user.id = String(newUser.id); // Convert number to string for compatibility
-          console.log('New user created successfully:', {
-            dbId: newUser.id,
-            dbIdType: typeof newUser.id,
-            assignedId: user.id,
-            assignedIdType: typeof user.id
-          });
+          user.id = newUser.id;
+          console.log('New user created successfully with ID:', newUser.id);
         } else {
           // Update existing user's last login
           console.log('Updating existing user:', existingUser.id);
@@ -111,13 +106,8 @@ export default defineConfig({
             .where(eq(Users.id, existingUser.id))
             .run();
 
-          user.id = String(existingUser.id); // Convert number to string for compatibility
-          console.log('User updated successfully:', {
-            dbId: existingUser.id,
-            dbIdType: typeof existingUser.id,
-            assignedId: user.id,
-            assignedIdType: typeof user.id
-          });
+          user.id = existingUser.id;
+          console.log('User updated successfully with ID:', existingUser.id);
         }
 
         return true;
@@ -145,7 +135,7 @@ export default defineConfig({
       
       if (session.user) {
         // Assign token ID to session user ID
-        session.user.id = token.id as string;
+        session.user.id = token.id as number;
         
         console.log('Session after modification', {
           userId: session.user.id,

--- a/src/components/SayingList.astro
+++ b/src/components/SayingList.astro
@@ -38,28 +38,16 @@ for (const saying of sayings) {
 
   // Get liked status if user is authenticated
   if (session?.user?.id) {
-    const userIdString = session.user.id.toString();
-    const isNumericId = /^\d+$/.test(userIdString);
-    
+    const userId = session.user.id;
+
     // Ensure the sayingId is a valid number
     if (Number.isFinite(sayingId)) {
       try {
-        let like;
-        if (isNumericId) {
-          // For numeric user IDs
-          like = await db
-            .select()
-            .from(Likes)
-            .where(and(eq(Likes.userId, Number(userIdString)), eq(Likes.sayingId, sayingId)))
-            .get();
-        } else {
-          // For string user IDs (like UUIDs from OAuth)
-          like = await db
-            .select()
-            .from(Likes)
-            .where(and(eq(Likes.userId, userIdString), eq(Likes.sayingId, sayingId)))
-            .get();
-        }
+        const like = await db
+          .select()
+          .from(Likes)
+          .where(and(eq(Likes.userId, userId), eq(Likes.sayingId, sayingId)))
+          .get();
         likedStatus.set(saying.id, !!like);
       } catch (error) {
         console.error(`Error checking like status for saying ${saying.id}:`, error);

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -33,8 +33,7 @@ interface ImportMeta {
 // Extend Astro's session type
 export interface ExtendedSession extends Session {
   user?: Session['user'] & {
-    id: string;
-    dbId?: number; // Added numeric database ID
+    id: number;
   };
 }
 

--- a/src/lib/db-service.ts
+++ b/src/lib/db-service.ts
@@ -89,25 +89,25 @@ export async function getAllSayings(): Promise<Saying[]> {
           ]);
 
           return {
-            id: String(saying.id),
-            intro: String(saying.intro),
-            type: String(saying.type),
+            id: saying.id,
+            intro: saying.intro,
+            type: saying.type,
             firstKind: saying.firstKind,
             secondKind: saying.secondKind,
-            userId: String(saying.userId),
+            userId: saying.userId,
             createdAt: saying.createdAt,
             updatedAt: saying.updatedAt || saying.createdAt, // Fallback for missing updatedAt
             introText: intro?.introText || 'Unknown intro',
             typeName: type?.name || 'Unknown type',
             intro_data: intro
               ? {
-                  id: String(intro.id),
+                  id: intro.id,
                   introText: intro.introText,
                 }
               : undefined,
             type_data: type
               ? {
-                  id: String(type.id),
+                  id: type.id,
                   name: type.name,
                 }
               : undefined,
@@ -117,12 +117,12 @@ export async function getAllSayings(): Promise<Saying[]> {
           
           // Return a basic version of the saying to prevent entire query from failing
           return {
-            id: String(saying.id),
-            intro: String(saying.intro),
-            type: String(saying.type),
+            id: saying.id,
+            intro: saying.intro,
+            type: saying.type,
             firstKind: saying.firstKind,
             secondKind: saying.secondKind,
-            userId: String(saying.userId),
+            userId: saying.userId,
             createdAt: saying.createdAt,
             updatedAt: saying.updatedAt || saying.createdAt,
             introText: 'Error loading intro',
@@ -266,25 +266,25 @@ export async function getUserSayings(userIdOrEmail: string | number): Promise<Sa
           ]);
 
           return {
-            id: String(saying.id),
-            intro: String(saying.intro),
-            type: String(saying.type),
+            id: saying.id,
+            intro: saying.intro,
+            type: saying.type,
             firstKind: saying.firstKind,
             secondKind: saying.secondKind,
-            userId: String(saying.userId),
+            userId: saying.userId,
             createdAt: saying.createdAt,
             updatedAt: saying.updatedAt || saying.createdAt,
             introText: intro?.introText || 'Unknown intro',
             typeName: type?.name || 'Unknown type',
             intro_data: intro
               ? {
-                  id: String(intro.id),
+                  id: intro.id,
                   introText: intro.introText,
                 }
               : undefined,
             type_data: type
               ? {
-                  id: String(type.id),
+                  id: type.id,
                   name: type.name,
                 }
               : undefined,
@@ -296,12 +296,12 @@ export async function getUserSayings(userIdOrEmail: string | number): Promise<Sa
           
           // Return a basic version of the saying to prevent entire query from failing
           return {
-            id: String(saying.id),
-            intro: String(saying.intro),
-            type: String(saying.type),
+            id: saying.id,
+            intro: saying.intro,
+            type: saying.type,
             firstKind: saying.firstKind,
             secondKind: saying.secondKind,
-            userId: String(saying.userId),
+            userId: saying.userId,
             createdAt: saying.createdAt,
             updatedAt: saying.updatedAt || saying.createdAt,
             introText: 'Error loading intro',

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -51,10 +51,10 @@ const auth = defineMiddleware(async ({ locals, request }, next) => {
               // Store the database user in locals for easy access
               locals.dbUser = user;
               
-              // Also add the database ID to the session user
+              // Also ensure the session user ID is numeric
               if (session.user) {
-                session.user.dbId = user.id;
-                logger.info('Updated session with database ID:', user.id);
+                session.user.id = user.id;
+                logger.info('Updated session with numeric ID:', user.id);
               }
             } else {
               logger.warn('Failed to upsert user, but continuing with session');

--- a/src/pages/api/create-saying.ts
+++ b/src/pages/api/create-saying.ts
@@ -191,7 +191,6 @@ export const POST: APIRoute = async ({ request, locals, redirect }) => {
     logger.info('API session:', {
       id: session?.user?.id,
       email: session?.user?.email,
-      dbId: session?.user?.dbId,
       locals: locals.dbUser ? true : false
     });
 
@@ -230,10 +229,10 @@ export const POST: APIRoute = async ({ request, locals, redirect }) => {
       userId = locals.dbUser.id;
       logger.info('Using user ID from locals:', userId);
     } 
-    // Option 2: Use dbId from session if available
-    else if (session.user.dbId) {
-      userId = session.user.dbId;
-      logger.info('Using dbId from session:', userId);
+    // Option 2: Use ID from session if available
+    else if (typeof session.user.id === 'number') {
+      userId = session.user.id;
+      logger.info('Using numeric ID from session:', userId);
     }
 
     // If we still don't have userId and we have an email, use our emergency function
@@ -248,8 +247,7 @@ export const POST: APIRoute = async ({ request, locals, redirect }) => {
       if (userId) {
         logger.info('Emergency user creation succeeded with ID:', userId);
         
-        // Update the session and locals with the new user ID
-        session.user.dbId = userId;
+        // Update the locals with the new user ID
         if (!locals.dbUser) {
           locals.dbUser = { id: userId };
         } else {

--- a/src/pages/api/delete-saying.ts
+++ b/src/pages/api/delete-saying.ts
@@ -64,8 +64,8 @@ export const POST: APIRoute = async ({ request }) => {
       );
     }
 
-    // Convert session user ID to number for comparison
-    const numericUserId = parseInt(session.user.id, 10);
+    // Session user ID is numeric
+    const numericUserId = session.user.id as number;
     
     if (saying.userId !== numericUserId) {
       return new Response(

--- a/src/pages/api/like.ts
+++ b/src/pages/api/like.ts
@@ -26,11 +26,11 @@ export const POST: APIRoute = async ({ request }) => {
 
     // Try multiple methods to get the user ID
     let userId: number | null = null;
-    
-    // Option 1: Use dbId from session if available
-    if (session.user.dbId) {
-      userId = session.user.dbId;
-      logger.info('Using dbId from session:', userId);
+
+    // Option 1: Use ID from session if available
+    if (typeof session.user.id === 'number') {
+      userId = session.user.id;
+      logger.info('Using numeric ID from session:', userId);
     }
     // Option 2: Try to look up by email directly
     else if (session.user.email) {

--- a/src/utils/user-db.ts
+++ b/src/utils/user-db.ts
@@ -287,20 +287,9 @@ export function getUserIdFromSession(session: Session | ExtendedSession | null):
     return null;
   }
   
-  // If this is already a numeric ID
+  // Session user IDs are stored as numbers
   if (typeof session.user.id === 'number') {
     return session.user.id;
-  }
-  
-  // Try parsing the ID as a number
-  const numericId = parseInt(session.user.id, 10);
-  if (!isNaN(numericId)) {
-    return numericId;
-  }
-  
-  // If we have a session.user.dbId (from middleware), use that
-  if (session.user.dbId && typeof session.user.dbId === 'number') {
-    return session.user.dbId;
   }
   
   logger.error('Could not get numeric ID from session');


### PR DESCRIPTION
## Summary
- keep user IDs as numbers in the session and throughout the APIs
- remove dbId fields
- adjust middleware and helper utilities
- return numeric IDs from database functions

## Testing
- `npm run lint` *(fails: jiti missing)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6855a3aa86908327a021594eaaa36bfa